### PR TITLE
TokenTransformationFilter add cache-size cache-ttl

### DIFF
--- a/openig-openam/src/test/java/org/forgerock/openig/openam/TokenTransformationFilterTest.java
+++ b/openig-openam/src/test/java/org/forgerock/openig/openam/TokenTransformationFilterTest.java
@@ -163,7 +163,7 @@ public class TokenTransformationFilterTest {
         TokenTransformationFilter filter =
                 new TokenTransformationFilter(transformationHandler,
                                               new URI("http://openam.example.com/"),
-                                              Expression.valueOf("${attributes.id_token}", String.class),"OPENIDCONNECT","SAML2");
+                                              Expression.valueOf("${attributes.id_token}", String.class),"OPENIDCONNECT","SAML2",null);
 
         Request request = new Request();
         filter.filter(context, request, next);
@@ -188,7 +188,7 @@ public class TokenTransformationFilterTest {
         TokenTransformationFilter filter =
                 new TokenTransformationFilter(transformationHandler,
                                               new URI("http://openam.example.com/"),
-                                              Expression.valueOf("${attributes.id_token}", String.class),"OPENIDCONNECT","SAML2");
+                                              Expression.valueOf("${attributes.id_token}", String.class),"OPENIDCONNECT","SAML2",null);
 
         Request request = new Request();
         assertNull(filter.filter(context, request, next));


### PR DESCRIPTION
The {@literal cache-size} attribute is an {@link Expression} specifying cache size,  default value 32000 
The {@literal cache-ttl} attribute is an {@link Expression} specifying cache ttl in ms, default value 0 ms (cache disabled)
