### PR TITLE
CVE-2024-38999 requirejs v2.3.6 was discovered to contain a prototype pollution 

### DIFF
--- a/openig-ui/src/main/resources/index.html
+++ b/openig-ui/src/main/resources/index.html
@@ -24,7 +24,7 @@
     <div id="dialogs"></div>
     <footer id="footer" class="footer text-muted"></footer>
 
-    <script data-main="main" src="libs/requirejs-2.1.14-min.js"></script>
+    <script data-main="main" src="libs/requirejs-2.3.7-min.js"></script>
 
 </body>
 

--- a/openig-ui/src/test/resources/qunit.html
+++ b/openig-ui/src/test/resources/qunit.html
@@ -27,6 +27,6 @@
     <script src="libs/qunit-1.15.0.js"></script>
     <script>QUnit.config.autostart = false;</script>
 
-    <script data-main="config" src="../www/libs/requirejs-2.1.14-min.js"></script>
+    <script data-main="config" src="../www/libs/requirejs-2.3.7-min.js"></script>
 </body>
 </html>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 			            <artifactItem>
 			              <groupId>org.openidentityplatform.commons.ui.libs</groupId>
 			              <artifactId>requirejs</artifactId>
-			              <version>2.1.14</version>
+			              <version>2.3.7</version>
 			              <classifier>min</classifier>
 			              <packaging>js</packaging>
 			              <downloadUrl>https://cdnjs.cloudflare.com/ajax/libs/require.js/{version}/require.{classifier}.{packaging}</downloadUrl>
@@ -535,7 +535,7 @@
 			            <artifactItem>
 			              <groupId>org.openidentityplatform.commons.ui.libs</groupId>
 			              <artifactId>requirejs</artifactId>
-			              <version>2.1.14</version>
+			              <version>2.3.7</version>
 			              <classifier>min</classifier>
 			              <packaging>js</packaging>
 			              <downloadUrl>https://cdnjs.cloudflare.com/ajax/libs/require.js/{version}/require.{classifier}.{packaging}</downloadUrl>
@@ -1083,7 +1083,7 @@
 		<dependency>
             <groupId>org.openidentityplatform.openam</groupId>
             <artifactId>openam</artifactId>
-            <version>15.2.0</version>
+            <version>15.2.2-SNAPSHOT</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1083,7 +1083,7 @@
 		<dependency>
             <groupId>org.openidentityplatform.openam</groupId>
             <artifactId>openam</artifactId>
-            <version>15.2.2-SNAPSHOT</version>
+            <version>15.2.2</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>


### PR DESCRIPTION
CVE-2024-38999 requirejs v2.3.6 was discovered to contain a prototype pollution via the function s.contexts._.configure. This vulnerability allows attackers to execute arbitrary code or cause a Denial of Service (DoS) via injecting arbitrary properties