### PR TITLE
Add CodeQL security analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,116 @@
+# The contents of this file are subject to the terms of the Common Development and
+# Distribution License (the License). You may not use this file except in compliance with the
+# License.
+#
+# You can obtain a copy of the License at legal/CDDLv1.0.txt. See the License for the
+# specific language governing permission and limitations under the License.
+#
+# When distributing Covered Software, include this CDDL Header Notice in each file and include
+# the License file at legal/CDDLv1.0.txt. If applicable, add the following below the CDDL
+# Header, with the fields enclosed by brackets [] replaced by your own identifying
+# information: "Portions copyright [year] [name of copyright owner]".
+#
+# Copyright 2026 3A Systems, LLC.
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ 'master' ]
+  pull_request:
+    branches: [ 'sustaining/5.4.x', 'master' ]
+  schedule:
+    # Weekly run, Mondays at 03:27 UTC
+    - cron: '27 3 * * 1'
+  # Allows running this workflow manually from the Actions tab or via the gh CLI.
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref to avoid the long-running,
+# eventually-cancelled analyses seen with the previous default setup.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      # Required to upload results to code scanning.
+      security-events: write
+      # Only needed for workflows in private repositories.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # This large multi-module Maven build is expensive to compile, so we
+          # use build-mode 'none': CodeQL builds its model straight from the
+          # Java/Kotlin sources without invoking Maven. This avoids the long,
+          # eventually-cancelled autobuild that the previous default setup hit.
+          #
+          # For higher precision (dataflow through compiled dependencies) switch
+          # this to 'manual' and uncomment the "Build with Maven" step below.
+          - language: java-kotlin
+            build-mode: none
+          # The openig-ui / openig-doc modules. Interpreted, so no compilation:
+          # extracted straight from source.
+          - language: javascript-typescript
+            build-mode: none
+          # Scans the repository's own GitHub Actions workflows.
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+          # Exclude test sources and generated / vendored output. With
+          # build-mode 'none' CodeQL extracts straight from source, so
+          # paths-ignore reliably scopes the analysis (it is honored for
+          # compiled languages only when build-mode is 'none').
+          config: |
+            paths-ignore:
+              - '**/src/test/**'
+              - '**/src/it/**'
+              # Third-party / vendored JavaScript — analysing it only adds noise.
+              - '**/*.min.js'
+              - '**/node_modules/**'
+              - '**/test-output/**'
+              # Generated Maven / build output (bundles vendored CodeMirror etc.).
+              - '**/target/**'
+              - '**/bin/**'
+
+      # --- Manual build (only used when build-mode is 'manual') -------------
+      # - name: Set up JDK 11
+      #   uses: actions/setup-java@v5
+      #   with:
+      #     java-version: '11'
+      #     distribution: 'zulu'
+      # - name: Cache Maven packages
+      #   uses: actions/cache@v6
+      #   with:
+      #     path: ~/.m2/repository
+      #     key: ${{ runner.os }}-m2-repository-${{ hashFiles('**/pom.xml') }}
+      #     restore-keys: ${{ runner.os }}-m2-repository
+      # - name: Build with Maven
+      #   env:
+      #     MAVEN_OPTS: -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.requestSentEnabled=true -Dmaven.wagon.http.retryHandler.count=10
+      #   run: mvn --batch-mode --errors -DskipTests -Dmaven.test.skip=true clean compile --file pom.xml
+      # ---------------------------------------------------------------------
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/openig-core/src/test/java/org/forgerock/openig/thread/MdcScheduledExecutorServiceDelegateTest.java
+++ b/openig-core/src/test/java/org/forgerock/openig/thread/MdcScheduledExecutorServiceDelegateTest.java
@@ -12,6 +12,7 @@
  * information: "Portions copyright [year] [name of copyright owner]".
  *
  * Copyright 2016 ForgeRock AS.
+ * Portions copyright 2026 3A Systems,LLC
  */
 
 package org.forgerock.openig.thread;
@@ -84,7 +85,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .schedule(nullable(Runnable.class), eq(1L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().schedule(runnable, 1, TimeUnit.SECONDS)).isSameAs(scheduledFuture);
+        assertThat((Object)executorService().schedule(runnable, 1, TimeUnit.SECONDS)).isSameAs(scheduledFuture);
 
         verify(delegate()).schedule(runnableCapture.capture(), eq(1L), eq(TimeUnit.SECONDS));
         assertThatCapturedRunnableIsMdcAware();
@@ -96,7 +97,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .schedule(nullable(Callable.class), eq(1L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().schedule(callable, 1, TimeUnit.SECONDS)).isSameAs(scheduledFuture);
+        assertThat((Object)executorService().schedule(callable, 1, TimeUnit.SECONDS)).isSameAs(scheduledFuture);
 
         verify(delegate()).schedule(callableCapture.capture(), eq(1L), eq(TimeUnit.SECONDS));
         assertThatCaptureCallableIsMdcAware();
@@ -107,7 +108,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .scheduleAtFixedRate(nullable(Runnable.class), eq(1L), eq(2L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().scheduleAtFixedRate(runnable, 1, 2, TimeUnit.SECONDS)).isSameAs(scheduledFuture);
+        assertThat((Object)executorService().scheduleAtFixedRate(runnable, 1, 2, TimeUnit.SECONDS)).isSameAs(scheduledFuture);
 
         verify(delegate()).scheduleAtFixedRate(runnableCapture.capture(), eq(1L), eq(2L), eq(TimeUnit.SECONDS));
         assertThatCapturedRunnableIsMdcAware();
@@ -118,7 +119,7 @@ public class MdcScheduledExecutorServiceDelegateTest extends MdcExecutorServiceD
         doReturn(scheduledFuture).when(delegate())
                                  .scheduleWithFixedDelay(nullable(Runnable.class), eq(1L), eq(2L), eq(TimeUnit.SECONDS));
 
-        assertThat(executorService().scheduleWithFixedDelay(runnable, 1, 2, TimeUnit.SECONDS))
+        assertThat((Object)executorService().scheduleWithFixedDelay(runnable, 1, 2, TimeUnit.SECONDS))
                 .isSameAs(scheduledFuture);
 
         verify(delegate()).scheduleWithFixedDelay(runnableCapture.capture(), eq(1L), eq(2L), eq(TimeUnit.SECONDS));

--- a/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/ClientRegistrationFilterTest.java
+++ b/openig-oauth2/src/test/java/org/forgerock/openig/filter/oauth2/client/ClientRegistrationFilterTest.java
@@ -12,6 +12,7 @@
  * information: "Portions Copyright [year] [name of copyright owner]".
  *
  * Copyright 2015-2016 ForgeRock AS.
+ * Portions Copyright 2026 3A Systems, LLC
  */
 package org.forgerock.openig.filter.oauth2.client;
 
@@ -149,7 +150,7 @@ public class ClientRegistrationFilterTest {
         verify(handler).handle(eq(context), captor.capture());
         Request request = captor.getValue();
         assertThat(request.getMethod()).isEqualTo("POST");
-        assertThat(request.getEntity().toString()).containsSequence("redirect_uris", "contact", "scopes");
+        assertThat(request.getEntity().toString()).contains("redirect_uris", "contact", "scopes");
     }
 
     @Test(expectedExceptions = RegistrationException.class)

--- a/openig-openam/src/test/java/org/forgerock/openig/openam/PolicyEnforcementFilterTest.java
+++ b/openig-openam/src/test/java/org/forgerock/openig/openam/PolicyEnforcementFilterTest.java
@@ -393,7 +393,7 @@ public class PolicyEnforcementFilterTest {
     public static void shouldSucceedToCreateBaseUri(final String realm) throws Exception {
         assertThat(normalizeToJsonEndpoint(new URI("http://www.example.com:8090/openam/"), realm).toASCIIString())
             .endsWith("/")
-            .containsSequence("http://www.example.com:8090/openam/json/",
+            .contains("http://www.example.com:8090/openam/json/",
                               realm != null ? realm.trim() : "");
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1059,7 +1059,7 @@
 		<dependency>
             <groupId>org.openidentityplatform.openam</groupId>
             <artifactId>openam</artifactId>
-            <version>16.0.6-SNAPSHOT</version>
+            <version>16.0.6</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1059,7 +1059,7 @@
 		<dependency>
             <groupId>org.openidentityplatform.openam</groupId>
             <artifactId>openam</artifactId>
-            <version>16.0.5</version>
+            <version>16.0.6-SNAPSHOT</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>


### PR DESCRIPTION
## Summary

Adds a **CodeQL** code-scanning workflow (`.github/workflows/codeql.yml`), adapted from the OpenAM CodeQL setup and tailored to OpenIG's layout.

- Analyzes **`java-kotlin`**, **`javascript-typescript`** (`openig-ui` / `openig-doc`), and **`actions`**.
- Uses **`build-mode: none`** for all languages — CodeQL extracts straight from source, avoiding the expensive multi-module Maven autobuild. A commented-out manual Maven build is included for higher-precision dataflow if ever needed.
- Runs on **push/PR to `master`**, a **weekly schedule** (Mon 03:27 UTC), and **manual dispatch**.
- `security-and-quality` query suite; `paths-ignore` excludes tests, `node_modules`, generated `target/`/`bin/` output, and `*.min.js`.
- Least-privilege permissions + `concurrency` cancellation of superseded runs.
- Dropped OpenAM's `csharp` language (OpenIG has no C# source).

## Note

This branch also carries earlier commits already present on it: three test fixes (`MdcScheduledExecutorServiceDelegateTest`, `ClientRegistrationFilterTest`, `PolicyEnforcementFilterTest`) and an OpenAM dependency version bump.